### PR TITLE
Windows support

### DIFF
--- a/main.c
+++ b/main.c
@@ -73,10 +73,12 @@ int main(int argc, char* argv[]) {
 	fclose(fp);
 	// patch
 	LOG("Patching %s\n",inFile);
+    #ifndef _WIN32
 	if(has_magic(iboot_in.buf)) { // make sure we aren't dealing with a packed IMG4 container
 		WARN("%s does not appear to be stripped\n",inFile);
 		return -1;
 	}
+    #endif
 	if(has_kernel_load_k(&iboot_in)) {
 		LOG("Does have kernel load\n");
 		if(bootArgs) {

--- a/main.c
+++ b/main.c
@@ -73,12 +73,10 @@ int main(int argc, char* argv[]) {
 	fclose(fp);
 	// patch
 	LOG("Patching %s\n",inFile);
-    #ifndef _WIN32
 	if(has_magic(iboot_in.buf)) { // make sure we aren't dealing with a packed IMG4 container
 		WARN("%s does not appear to be stripped\n",inFile);
 		return -1;
 	}
-    #endif
 	if(has_kernel_load_k(&iboot_in)) {
 		LOG("Does have kernel load\n");
 		if(bootArgs) {

--- a/newpatch.c
+++ b/newpatch.c
@@ -22,6 +22,26 @@
 #define _GNU_SOURCE
 #include "newpatch.h"
 
+#ifdef _WIN32
+void *memmem(const void *haystack, size_t haystack_len, 
+    const void * const needle, const size_t needle_len)
+{
+    if (haystack == NULL) return NULL; // or assert(haystack != NULL);
+    if (haystack_len == 0) return NULL;
+    if (needle == NULL) return NULL; // or assert(needle != NULL);
+    if (needle_len == 0) return NULL;
+
+    for (const char *h = haystack;
+            haystack_len >= needle_len;
+            ++h, --haystack_len) {
+        if (!memcmp(h, needle, needle_len)) {
+            return h;
+        }
+    }
+    return NULL;
+}
+#endif
+
 /* begin functions from iBoot32Patcher by iH8sn0w*/
 bool has_magic(uint8_t* buf) {
 	uint8_t* magic;

--- a/newpatch.c
+++ b/newpatch.c
@@ -44,9 +44,9 @@ void *memmem(const void *haystack, size_t haystack_len,
 
 /* begin functions from iBoot32Patcher by iH8sn0w*/
 bool has_magic(uint8_t* buf) {
-	uint8_t* magic;
-	memcpy(magic,buf+7,4);
-	if(memcmp(magic,IMAGE4_MAGIC,4) == 0) {
+	uint32_t magic;
+	magic = *(uint32_t*)(buf+7);
+	if(memcmp(&magic,IMAGE4_MAGIC,4) == 0) {
 		return true;
 	}
 	return false;


### PR DESCRIPTION
Hi,
Since `memmem()` is not available in windows, I used a custom implementation and successfully build kairos on mingw64. But[ this block](https://github.com/dayt0n/kairos/blob/a5a6309b780dcbe2b369d68fb3c1b598a3b4036a/main.c#L76-L79) causes segmentation fault while patching iboot raw file. For now I bypassed `has_magic()` check on windows and everything seems to be working fine.

It's nice to have an iBoot patcher on windows.