### PR TITLE
replace ret with branch instruction for RSA patch

### DIFF
--- a/instructions.c
+++ b/instructions.c
@@ -113,9 +113,15 @@ uint32_t replace_adr_addr(addr_t offset, uint32_t insn, int64_t addr) {
 uint32_t new_branch(int64_t where, int64_t addr) {
     int64_t res = 0;
     uint32_t opcode = 0;
-    opcode |= SET_BITS(0x5,26);
-    res = (addr - where) / 4;
-    opcode |= (res % (1<<25));
+    if(addr > where) {
+        opcode |= SET_BITS(0x5,26);
+        res = (addr - where) / 4;
+        opcode |= (res % (1<<25));
+    } else {
+        opcode |= SET_BITS(0x3,27);
+        res = (where - addr) / 4;
+        opcode -= (res % (1<<25));
+    }
     return opcode;
 }
 

--- a/newpatch.c
+++ b/newpatch.c
@@ -285,11 +285,23 @@ void do_rsa_sigcheck_patch(struct iboot64_img* iboot_in, addr_t img4Xref, bool p
 	LOG("Found start of sub_%llx\n",iboot_in->base+getPartialRefFtop);
 	addr_t x2_adr = 0;
 	addr_t x3_adr = 0;
+
+	insn_type_t x3_type = adr;
+	if (iboot_in->VERS < 2817){ // iOS 8
+		/*
+		* adr        x2, #0x83d38d680 <-
+		* nop
+		* add        x3, sp, #0x9
+		* ...
+		*/
+		x3_type = add;
+	}
+    
 	while(1) {
 		getPartialRefFtop += 4;
 		if(get_type(get_insn(iboot_in->buf,getPartialRefFtop)) == adr && get_rd(get_insn(iboot_in->buf,getPartialRefFtop)) == 2)
 			x2_adr = getPartialRefFtop;
-		else if(get_type(get_insn(iboot_in->buf,getPartialRefFtop)) == adr && get_rd(get_insn(iboot_in->buf,getPartialRefFtop)) == 3)
+		else if(get_type(get_insn(iboot_in->buf,getPartialRefFtop)) == x3_type && get_rd(get_insn(iboot_in->buf,getPartialRefFtop)) == 3)
 			x3_adr = getPartialRefFtop;
 		else if(get_type(get_insn(iboot_in->buf,getPartialRefFtop)) == bl) {
 			if(x2_adr && x3_adr)


### PR DESCRIPTION
RSA patch for older versions seem to work for decrypted images, but not for encrypted images. 
also patch use the patch for ios 10 and above seems to destroy the next instruction of ret instruction that is necessary for ios 9, so I replaced the ret instruction with a branch instruction and jump to the ret0 gadget.

ret0 does not appear to exist in older versions of iBoot, so search for the NOP and create a new ret0.